### PR TITLE
Add link for ePC

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,6 +18,8 @@
     - [Sequence Memory with Temporal Predictive Coding](https://github.com/C16Mftang/sequential-memory)
 
     - [Temporal Predictive Coding](https://github.com/C16Mftang/temporal-predictive-coding)
+ 
+    - [Error-based Predictive Coding](https://github.com/cgoemaere/error_based_PC) _(with PyTorch Lightning)_
 
 - **Action selection in the basal ganglia**
 


### PR DESCRIPTION
Added a new link for Error-based Predictive Coding, with a note about the use of PyTorch Lightning (which is a nice perk, in my opinion)